### PR TITLE
BA-4: Make "+" button take user to search screen

### DIFF
--- a/MyReadingList/MyReadingList/MyReadingListView.swift
+++ b/MyReadingList/MyReadingList/MyReadingListView.swift
@@ -11,15 +11,13 @@ import SwiftUI
 struct MyReadingListView: View {
     var body: some View {
         NavigationView {
-            VStack {
+            HStack {
                 List {
-                    HStack{
-                        NavigationLink {
-                            SearchView()
-                        } label: {
-                            Image(systemName: "plus.circle")
-                            Text(NSLocalizedString("ui.myReadingList.addABook.button", value: "Add a book", comment: "Add a Book button in MyReadingList screen"))
-                        }
+                    NavigationLink {
+                        SearchView()
+                    } label: {
+                        Image(systemName: "plus.circle")
+                        Text(NSLocalizedString("ui.myReadingList.addABook.button", value: "Add a book", comment: "Add a Book button in MyReadingList screen"))
                     }
                 }
             }.navigationTitle(NSLocalizedString("ui.myReadingList.title", value: "My Reading List", comment: "title for the MyReadingList screen"))

--- a/MyReadingList/MyReadingList/MyReadingListView.swift
+++ b/MyReadingList/MyReadingList/MyReadingListView.swift
@@ -15,8 +15,8 @@ struct MyReadingListView: View {
                 List {
                     HStack{
                         NavigationLink {
-                                    SearchView()
-                    } label: {
+                            SearchView()
+                        } label: {
                             Image(systemName: "plus.circle")
                             Text(NSLocalizedString("ui.myReadingList.addABook.button", value: "Add a book", comment: "Add a Book button in MyReadingList screen"))
                         }

--- a/MyReadingList/MyReadingList/MyReadingListView.swift
+++ b/MyReadingList/MyReadingList/MyReadingListView.swift
@@ -10,12 +10,8 @@ import SwiftUI
 
 struct MyReadingListView: View {
     var body: some View {
-        VStack {
-            Text(NSLocalizedString("ui.myReadingList.title", value: "My Reading List", comment: "title for the MyReadingList screen"))
-                .font(.headline)
-            Spacer()
-            
-            NavigationView {
+        NavigationView {
+            VStack {
                 List {
                     HStack{
                         NavigationLink {
@@ -26,7 +22,7 @@ struct MyReadingListView: View {
                         }
                     }
                 }
-            }
+            }.navigationTitle(NSLocalizedString("ui.myReadingList.title", value: "My Reading List", comment: "title for the MyReadingList screen"))
         }
     }
 }

--- a/MyReadingList/MyReadingList/MyReadingListView.swift
+++ b/MyReadingList/MyReadingList/MyReadingListView.swift
@@ -16,7 +16,6 @@ struct MyReadingListView: View {
                     NavigationLink {
                         SearchView()
                     } label: {
-                        Image(systemName: "plus.circle")
                         Text(NSLocalizedString("ui.myReadingList.addABook.button", value: "Add a book", comment: "Add a Book button in MyReadingList screen"))
                     }
                 }

--- a/MyReadingList/MyReadingList/MyReadingListView.swift
+++ b/MyReadingList/MyReadingList/MyReadingListView.swift
@@ -11,8 +11,8 @@ import SwiftUI
 struct MyReadingListView: View {
     var body: some View {
         NavigationView {
-            HStack {
-                List {
+            List {
+                HStack {
                     NavigationLink {
                         SearchView()
                     } label: {

--- a/MyReadingList/MyReadingList/MyReadingListView.swift
+++ b/MyReadingList/MyReadingList/MyReadingListView.swift
@@ -12,12 +12,10 @@ struct MyReadingListView: View {
     var body: some View {
         NavigationView {
             List {
-                HStack {
-                    NavigationLink {
-                        SearchView()
-                    } label: {
-                        Text(NSLocalizedString("ui.myReadingList.addABook.button", value: "Add a book", comment: "Add a Book button in MyReadingList screen"))
-                    }
+                NavigationLink {
+                    SearchView()
+                } label: {
+                    Text(NSLocalizedString("ui.myReadingList.addABook.button", value: "Add a book", comment: "Add a Book button in MyReadingList screen"))
                 }
             }.navigationTitle(NSLocalizedString("ui.myReadingList.title", value: "My Reading List", comment: "title for the MyReadingList screen"))
         }

--- a/MyReadingList/MyReadingList/MyReadingListView.swift
+++ b/MyReadingList/MyReadingList/MyReadingListView.swift
@@ -15,14 +15,16 @@ struct MyReadingListView: View {
                 .font(.headline)
             Spacer()
             
-            List {
-                HStack{
-                    Button {
-                        //do nothing for now
+            NavigationView {
+                List {
+                    HStack{
+                        NavigationLink {
+                                    SearchView()
                     } label: {
-                        Image(systemName: "plus.circle")
+                            Image(systemName: "plus.circle")
+                            Text(NSLocalizedString("ui.myReadingList.addABook.button", value: "Add a book", comment: "Add a Book button in MyReadingList screen"))
+                        }
                     }
-                    Text(NSLocalizedString("ui.myReadingList.addABook.button", value: "Add a book", comment: "Add a Book button in MyReadingList screen"))
                 }
             }
         }

--- a/MyReadingList/MyReadingList/SearchView.swift
+++ b/MyReadingList/MyReadingList/SearchView.swift
@@ -10,10 +10,8 @@ import SwiftUI
 struct SearchView: View {
     var body: some View {
         VStack{
-            Text(NSLocalizedString("ui.search.title", value: "Search", comment: "title for the Search screen"))
-                .font(.headline)
-            Spacer()
-        }
+            // placeholder
+        }.navigationTitle(NSLocalizedString("ui.search.title", value: "Search", comment: "title for the Search screen"))
     }
 }
 


### PR DESCRIPTION
### Description
In this Pull Request when I add the Navigation view to MyReadingList view,  by default an arrow was added to the the tappable cell. In this point I had a  "+" button and the default arrow, there is no need of two indicators for the tappable element, that's why I decided to keep the default one and remove the "+" button.
Adding the Search view to the navigation stuck requires a change to the Search view, achieved by replacing the title with a navigation title.

### Screenshots

                                    MyReadingList view   
                                          
| Before | After |
| --- | --- |
| <img width="300" alt="Screenshot 2021-12-22 at 12 28 42" src="https://user-images.githubusercontent.com/59181148/147092983-e1d69410-e9e6-45ba-9095-f27820c296c6.png">|<img width="300" alt="Screenshot 2021-12-22 at 12 15 43" src="https://user-images.githubusercontent.com/59181148/147091454-f8f85b66-260a-45a3-8022-823548926f21.png">| 

                                         Search view 
| Before | After |
| --- | --- |
| <img width="300" alt="Screenshot 2021-12-22 at 12 50 45" src="https://user-images.githubusercontent.com/59181148/147095682-13d55b2c-e1ae-404b-9bea-06f5d65983fb.png">  |  <img width="300" alt="Screenshot 2021-12-22 at 13 19 08" src="https://user-images.githubusercontent.com/59181148/147098910-a56661d4-bb2b-4704-9ea2-b89c93fa8739.png"> |

### Links
Jira link to the ticket: https://katyaland.atlassian.net/browse/BA-4
